### PR TITLE
Added confirm modal dialog for account creation

### DIFF
--- a/app/components/account-create/component.js
+++ b/app/components/account-create/component.js
@@ -1,0 +1,11 @@
+import Component from '@ember/component';
+
+import { argument } from '@ember-decorators/argument';
+
+export default class AccountCreateComponent extends Component {
+  @argument wallet = null;
+
+  @argument onCreate = null;
+
+  @argument onCancel = null;
+}

--- a/app/components/account-create/template.hbs
+++ b/app/components/account-create/template.hbs
@@ -1,0 +1,20 @@
+{{#bs-modal position='center' onHide=(action (optional onCancel)) onSubmit=(action onCreate) as |modal|}}
+  {{#modal.header}}
+    <h4 class="modal-title">
+      {{fa-icon 'exclamation-triangle' class="text-danger"}}
+      {{t 'wallets.accounts.create.title'}}
+    </h4>
+  {{/modal.header}}
+  {{#modal.body}}
+    <p class="lead">{{t 'wallets.accounts.create.lead'}}</p>
+    <p>{{t 'wallets.accounts.create.body' htmlSafe=true}}</p>
+  {{/modal.body}}
+  {{#modal.footer}}
+    {{#bs-button onClick=(action modal.close) type="secondary"}}
+      {{t 'cancel'}}
+    {{/bs-button}}
+    {{#bs-button type="danger" icon="fa fa-plus-square" buttonType='submit'}}
+      {{t 'wallets.accounts.create.createButton'}}
+    {{/bs-button}}
+  {{/modal.footer}}
+{{/bs-modal}}

--- a/app/components/navigation-bar/component.js
+++ b/app/components/navigation-bar/component.js
@@ -8,8 +8,6 @@ export default class NavigationBarComponent extends Component {
 
   @argument show = false;
 
-  @argument onCreateAccount = null;
-
   @argument onChangeRepresentative = null;
 
   @argument onChangePassword = null;

--- a/app/components/navigation-bar/template.hbs
+++ b/app/components/navigation-bar/template.hbs
@@ -22,9 +22,9 @@
         {{/link-to}}
       </li>
       <li class="nav-item">
-        <a href="#" class="nav-link" {{action onCreateAccount wallet}}>
+        {{#link-to 'wallets.overview.accounts.create' wallet class="nav-link"}}
           {{fa-icon "plus-square"}} {{t 'wallets.overview.create'}}
-        </a>
+        {{/link-to}}
       </li>
       <li class="nav-item">
         {{#link-to 'wallets.overview.settings' wallet class="nav-link"}}

--- a/app/router.js
+++ b/app/router.js
@@ -26,6 +26,7 @@ Router.map(function routerMap() {
     this.route('overview', function overviewRoute() {
       this.route('settings');
       this.route('accounts', { path: '/:account_id' }, function accountsRoute() {
+        this.route('create');
         this.route('send');
         this.route('history');
         this.route('settings');

--- a/app/wallets/overview/accounts/create/route.js
+++ b/app/wallets/overview/accounts/create/route.js
@@ -1,0 +1,25 @@
+import Route from '@ember/routing/route';
+
+import { service } from '@ember-decorators/service';
+import { action } from '@ember-decorators/object';
+
+export default class WalletsOverviewCreateAccountRoute extends Route {
+  @service intl = null;
+
+  @service flashMessages = null;
+
+  @action
+  async create(wallet) {
+    const account = this.store.createRecord('account');
+    account.set('wallet', wallet);
+    await account.save();
+    const message = this.get('intl').t('wallets.overview.created');
+    this.get('flashMessages').success(message);
+    return this.transitionTo('wallets.overview');
+  }
+
+  @action
+  cancel() {
+    return this.transitionTo('wallets.overview');
+  }
+}

--- a/app/wallets/overview/accounts/create/template.hbs
+++ b/app/wallets/overview/accounts/create/template.hbs
@@ -1,0 +1,1 @@
+{{account-create wallet=model onCreate=(action (route-action 'create' model)) onCancel=(action (route-action 'cancel'))}}

--- a/app/wallets/overview/template.hbs
+++ b/app/wallets/overview/template.hbs
@@ -2,7 +2,7 @@
   {{balance-overview wallet=model currency=currency onChangeCurrency=(route-action 'changeCurrency')}}
 {{/if}}
 
-{{wallet-overview wallet=model accounts=sortedAccounts hideHistory=hideHistory createAccount=(route-action 'createAccount') currentSlide=slide onChangeSlide=(route-action 'changeSlide')}}
+{{wallet-overview wallet=model accounts=sortedAccounts hideHistory=hideHistory currentSlide=slide onChangeSlide=(route-action 'changeSlide')}}
 
 {{liquid-outlet class="history"}}
 

--- a/app/wallets/route.js
+++ b/app/wallets/route.js
@@ -39,16 +39,6 @@ export default class WalletsRoute extends Route.extend(
   }
 
   @action
-  async createAccount(wallet) {
-    const account = this.store.createRecord('account');
-    account.set('wallet', wallet);
-    await account.save();
-
-    const message = this.get('intl').t('wallets.overview.created');
-    this.get('flashMessages').success(message);
-  }
-
-  @action
   async changeRepresentative(model, changeset) {
     const flashMessages = this.get('flashMessages');
     const wallet = get(model, 'id');

--- a/app/wallets/template.hbs
+++ b/app/wallets/template.hbs
@@ -1,4 +1,4 @@
-{{navigation-bar wallet=model onCreateAccount=(route-action 'createAccount')}}
+{{navigation-bar wallet=model}}
 
 <main role="main">
   {{notification-center}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -122,6 +122,14 @@ wallets:
       none: 'No history yet'
     settings:
       representative: 'Representative Account'
+    create:
+      title: 'Create Account'
+      lead: 'Are you sure to create a new account?'
+      body: >
+        <strong>Warning</strong>: If you proceed you will create a new MIKRON account which can't be deleted later.
+        You should only proceed if you need an additional MIKRON account number beside your current one(s).
+        Are you sure to proceed?
+      createButton: 'Create'
   overview:
     none: 'No accounts in wallet.'
     create: 'Create Account'

--- a/translations/hu-hu.yaml
+++ b/translations/hu-hu.yaml
@@ -126,6 +126,14 @@ wallets:
       none: 'Nincs még számla történet'
     settings:
       representative: 'Képviselő számla'
+    create:
+      title: 'Új számla létrehozása'
+      lead: 'Biztosan szeretnél új számlát létrehozni?'
+      body: >
+        <strong>Figyelmeztetés</strong>: Ez a művelet egy új MIKRON számlaszámot fog létrehozni, amit később nem fogsz tudni
+        törölni. Csak abban az esetben érdemes ezt megtenni, ha a jelenlegi(ek) mellett szeretnél másik MIKRON számlaszámmal
+        is rendelkezni. Biztosan folytatod?
+      createButton: 'Lérehozás'
   overview:
     none: 'Nincs a tárcában számla.'
     create: 'Új számla létrehozása'


### PR DESCRIPTION
Users tend to accidentally create new accounts even if they don't need it. I implemented a new modal window which can explain what's going to happen. This way users will have the opportunity to cancel the new account creation or proceed if they want to.
The modal's texts can be changed in the resources files (en-us.yaml and hu-hu.yaml). All texts have the same key suffix: "wallets.accounts.create"