### PR TITLE
Certificate expiry

### DIFF
--- a/ember-electron/daemon.js
+++ b/ember-electron/daemon.js
@@ -54,6 +54,7 @@ const generateCert = (commonName) => {
     keySize: 2048,
     algorithm: 'sha256',
     extensions: [],
+    days: 1095,
   });
 };
 


### PR DESCRIPTION
Use 3 years for expiry for generated certificate.
Fixes #45 .